### PR TITLE
added debug section and nostree

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Below is a list of software and hardware remote signers
 + [nsecBunker - nsecbunker.com](https://nsecbunker.com)
 + [Nsec.app - nsec.app](https://nsec.app)
 
+### Debug
+
++ [Nostr Army Knife - NAK](https://github.com/fiatjaf/nak/)
+
 ## Clients
 
 Below are listed clients that work with Nostr Remote Signers
@@ -27,5 +31,6 @@ Below are listed clients that work with Nostr Remote Signers
 + [Snort.social](https://snort.social/) - A social media client
 + [Coracle](https://coracle.social/) - A social media client
 + [Wikifreedia](https://wikifreedia.vercel.app/) - A new take on Wikis
++ [Nostree](https://nostree.me/) - A Nostr-based application to create, manage and discover link lists.
 
 Are you a maintainer of a Nostr client and are interested in implementing NIP46 in your client? [Get in touch](https://njump.me/nprofile1qqsxsvs3h524c7mkfe9enw3x8g23mqfqn0n62e4zhvvhrhqmh5ahzhsjhwnjl)


### PR DESCRIPTION
Thanks for starting this repo.
I've added a debug section inside Remote Nostr Signers where nak is included, as it has a built-in bunker that can be used to debug connectionStrings (not OAuth flow) and where nip46 was implemented in the last release of the repo.